### PR TITLE
Add support for npm prebuild config env vars

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 module.exports = input => {
-	const arch = require('arch')();
+	const platform = process.env.npm_config_platform || process.platform;
+	const arch = process.env.npm_config_arch || require('arch')();
+
 	const check = (bool, key, val) => (!bool || !key || key === val);
 
-	return input.filter(x => [process.platform, arch].every((y, i) => check(i === 0, x.os, y) && check(i === 1, x.arch, y)));
+	return input.filter(x => [platform, arch].every((y, i) => check(i === 0, x.os, y) && check(i === 1, x.arch, y)));
 };


### PR DESCRIPTION
Add support for the commonly used environment variables `npm_config_platform` and `npm_config_arch`. These configuration values are often used for selecting prebuilt binaries in order to enable cross-platform building of packages. That is used for instance by packages such as [shap](https://sharp.pixelplumbing.com/install#cross-platform) and [electron](https://www.electronjs.org/docs/latest/tutorial/using-native-node-modules#using-npm).